### PR TITLE
Click only when button is active

### DIFF
--- a/netflix_adblock.js
+++ b/netflix_adblock.js
@@ -1,5 +1,5 @@
 setInterval(function () {
-  let button = document.querySelector('.originalsBackgroundAutoplayTrailer');
+  let button = document.querySelector('.originalsBackgroundAutoplayTrailer.active');
 
   if (button) {
     button.click();


### PR DESCRIPTION
Thank you for this! It seems like a simple and effective solution to a really annoying anti-feature. The extension works fine, but causes the Netflix controls to constantly pop up for me while the extension is enabled.

This change makes it so it only attempts to click the button when it's visible on screen.